### PR TITLE
Set up continuous integration with Github Actions

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -12,7 +12,7 @@ jobs:
         - windows-latest
     runs-on: ${{matrix.os}}
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Install
       uses: actions-rs/toolchain@v1
       with:

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -1,0 +1,35 @@
+name: Rust
+
+on: [push]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os:
+        - macos-latest
+        - ubuntu-latest
+        - windows-latest
+    runs-on: ${{matrix.os}}
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        profile: minimal
+        components: clippy, rustfmt
+        override: true
+    - name: Version
+      run: |
+        rustup --version
+        cargo --version
+        cargo clippy --version
+    - name: Build
+      run: cargo build --verbose
+    - name: Test
+      run: cargo test --verbose
+    - name: Lint
+      run: cargo clippy
+    - name: Format
+      run: cargo fmt -- --check


### PR DESCRIPTION
Runs the following on Linux, macOS, and Windows:
- Download and install latest rust
- Print out version of toolchain, for reference
- Build w/cargo build
- Test w/cargo test
- Lint w/cargo clippy
- Complain if the code isn't formatted with cargo fmt